### PR TITLE
fix pass datatype in db

### DIFF
--- a/app/repositories/PlayerRepository.scala
+++ b/app/repositories/PlayerRepository.scala
@@ -88,14 +88,14 @@ object PlayerRepository extends SQLSyntaxSupport[Player] {
 
   // find by primary key
   def findByCredentials(username: String, encodedPass: String)(implicit session: DBSession): Option[Player] = withSQL {
-    select.from(PlayerRepository as p).where.eq(p.username, username).and.eq(p.encodedPass, encodedPass).and.append(isNotDeleted)
+    select.from(PlayerRepository as p).where.eq(p.username, username).and.eq(p.encodedPass, encodedPass.getBytes).and.append(isNotDeleted)
   }.map(PlayerRepository(p)).single.apply()
 
   def create(username: String, encodedPass: String, createdAt: ZonedDateTime = ZonedDateTime.now)(implicit session: DBSession): Player = {
     val id = withSQL {
       insert.into(PlayerRepository).namedValues(
         column.username -> username,
-        column.encodedPass -> encodedPass,
+        column.encodedPass -> encodedPass.getBytes,
         column.createdAt -> createdAt)
     }.updateAndReturnGeneratedKey.apply()
 

--- a/conf/scripts/init-db.sql
+++ b/conf/scripts/init-db.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS player (
   id serial primary key,
   username varchar(256) not null,
-  encoded_pass varchar(256) not null,
+  encoded_pass bytea not null,
   created_at timestamp not null,
   deleted_at timestamp,
   UNIQUE(username)


### PR DESCRIPTION
## Summary

There was an error in DataBase when trying to save a password whose encoded hash had a null character.
The cause is that PostgreSQL doesn't allow to save a null character in a `varchar` (more info at https://stackoverflow.com/a/1348551/3392786).
The solution is to change the data type from `varchar` to `bytea`.

## Dependencies

None.

## Tests

- [x] Manual
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Functional Tests
